### PR TITLE
Support for DPI scaling

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -34,6 +34,8 @@ target_link_libraries(samples PUBLIC box2d glfw imgui::imgui glad::glad)
 # message(STATUS "runtime = ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 # message(STATUS "binary = ${CMAKE_CURRENT_BINARY_DIR}")
 
+set_target_properties(samples PROPERTIES VS_DPI_AWARE "ON")
+
 # Copy font files, etc
 add_custom_command(
         TARGET samples POST_BUILD


### PR DESCRIPTION
This PR fixes how scaling is handled and make sure UI from samples render properly regardles of user DPI settings.

Scaling is achieved by 'virtualizing' window size on Windows. Windows make that user responsibility. By default `g_camera` request 1920x1080 window to be created. With 150 DPI size of this window should be multiplied by 1.5. UI remain in 1920x1080 resolution. Font retain same size for the UI, but atlas is rendered in higher resolution to match current DPI. This mean all hardcoded constants and offsets will be displayed correctly on any DPI.

GLFW3 squashes two ways of dealing with DPI into one single API. On Windows return how window should be scalled, on macOS return how framebuffer is scalled. In samples application there is a distinction between window scale and framebuffer scale now.

However, pull requests for build system improvements are often accepted.
|100 DPI<br/><img alt="windows-100dpi" src="https://user-images.githubusercontent.com/1197433/218339091-576ca5af-7c6b-4f87-bff4-64df3ab3a77b.png">|150 DPI (current)<br/><img alt="windows-150dpi-broken" src="https://user-images.githubusercontent.com/1197433/218339093-3ba43f2d-9ec0-4c9e-8c8d-432e6f626ec5.png">|
-|-
|150 DPI (expected, resized screenshot above)<br/><img alt="windows-150dpi-expected" src="https://user-images.githubusercontent.com/1197433/218339095-97290a10-b855-44fe-a0d9-ed411cfb4968.png">|150 DPI (this PR)<br/><img alt="windows-150dpi-fixed" src="https://user-images.githubusercontent.com/1197433/218339096-c4b64748-9821-4e15-b8fa-d9bc73a9fc5b.png">|

As a bonus, this is how samples does look like on macOS with HiDPI after this PR.
<img width="50%" alt="macOS-hidpi@2 0" src="https://user-images.githubusercontent.com/1197433/218339090-5739cbb5-4124-4880-a5ce-145258939ffd.png">
