### PR TITLE
Chain sample

### DIFF
--- a/include/box2d/event_types.h
+++ b/include/box2d/event_types.h
@@ -31,8 +31,8 @@ typedef struct b2SensorEvents
 {
 	b2SensorBeginTouchEvent* beginEvents;
 	b2SensorEndTouchEvent* endEvents;
-	int beginCount;
-	int endCount;
+	int32_t beginCount;
+	int32_t endCount;
 } b2SensorEvents;
 
 /// A begin touch event is generated when two shapes begin touching. By convention the manifold
@@ -72,8 +72,8 @@ typedef struct b2ContactEvents
 {
 	b2ContactBeginTouchEvent* beginEvents;
 	b2ContactEndTouchEvent* endEvents;
-	int beginCount;
-	int endCount;
+	int32_t beginCount;
+	int32_t endCount;
 } b2ContactEvents;
 
 /// The contact data for two shapes. By convention the manifold normal points
@@ -104,5 +104,5 @@ typedef struct b2BodyMoveEvent
 typedef struct b2BodyEvents
 {
 	b2BodyMoveEvent* moveEvents;
-	int moveCount;
+	int32_t moveCount;
 } b2BodyEvents;

--- a/include/box2d/geometry.h
+++ b/include/box2d/geometry.h
@@ -75,7 +75,7 @@ typedef struct b2Polygon
 	b2Vec2 normals[b2_maxPolygonVertices];
 	b2Vec2 centroid;
 	float radius;
-	int count;
+	int32_t count;
 } b2Polygon;
 
 /// A line segment with two-sided collision.

--- a/include/box2d/manifold.h
+++ b/include/box2d/manifold.h
@@ -50,7 +50,7 @@ typedef struct b2Manifold
 {
 	b2ManifoldPoint points[2];
 	b2Vec2 normal;
-	int pointCount;
+	int32_t pointCount;
 } b2Manifold;
 
 /// Use this to initialize your manifold

--- a/include/box2d/math_functions.h
+++ b/include/box2d/math_functions.h
@@ -23,8 +23,8 @@
 #define B2_CLAMP(A, B, C) B2_MIN(B2_MAX(A, B), C)
 
 static const b2Vec2 b2Vec2_zero = {0.0f, 0.0f};
-static const b2Rot b2Rot_identity = {0.0f, 1.0f};
-static const b2Transform b2Transform_identity = {{0.0f, 0.0f}, {0.0f, 1.0f}};
+static const b2Rot b2Rot_identity = {1.0f, 0.0f};
+static const b2Transform b2Transform_identity = {{0.0f, 0.0f}, {1.0f, 0.0f}};
 static const b2Mat22 b2Mat22_zero = {{0.0f, 0.0f}, {0.0f, 0.0f}};
 
 /// Vector dot product
@@ -180,7 +180,7 @@ B2_INLINE float b2DistanceSquared(b2Vec2 a, b2Vec2 b)
 B2_INLINE b2Rot b2MakeRot(float angle)
 {
 	// todo determinism
-	b2Rot q = {sinf(angle), cosf(angle)};
+	b2Rot q = {cosf(angle), sinf(angle)};
 	return q;
 }
 
@@ -189,7 +189,7 @@ B2_INLINE b2Rot b2NormalizeRot(b2Rot q)
 {
 	float mag = sqrtf(q.s * q.s + q.c * q.c);
 	float invMag = mag > 0.0 ? 1.0f / mag : 0.0f;
-	b2Rot qn = {q.s * invMag, q.c * invMag};
+	b2Rot qn = {q.c * invMag, q.s * invMag};
 	return qn;
 }
 
@@ -207,8 +207,8 @@ B2_INLINE b2Rot b2NLerp(b2Rot q1, b2Rot q2, float t)
 {
 	float omt = 1.0f - t;
 	b2Rot q = {
-		omt * q1.s + t * q2.s,
 		omt * q1.c + t * q2.c,
+		omt * q1.s + t * q2.s,
 	};
 
 	return b2NormalizeRot(q);
@@ -219,14 +219,14 @@ B2_INLINE b2Rot b2NLerp(b2Rot q1, b2Rot q2, float t)
 ///	@param deltaAngle the angular displacement in radians
 B2_INLINE b2Rot b2IntegrateRotation(b2Rot q1, float deltaAngle)
 {
-	// ds/dt = omega * cos(t)
 	// dc/dt = -omega * sin(t)
-	// s2 = s1 + omega * h * c1
+	// ds/dt = omega * cos(t)
 	// c2 = c1 - omega * h * s1
-	b2Rot q2 = {q1.s + deltaAngle * q1.c, q1.c - deltaAngle * q1.s};
+	// s2 = s1 + omega * h * c1
+	b2Rot q2 = {q1.c - deltaAngle * q1.s, q1.s + deltaAngle * q1.c};
 	float mag = sqrtf(q2.s * q2.s + q2.c * q2.c);
 	float invMag = mag > 0.0 ? 1.0f / mag : 0.0f;
-	b2Rot qn = {q2.s * invMag, q2.c * invMag};
+	b2Rot qn = {q2.c * invMag, q2.s * invMag};
 	return qn;
 }
 

--- a/include/box2d/math_types.h
+++ b/include/box2d/math_types.h
@@ -15,8 +15,8 @@ typedef struct b2Vec2
 /// This is similar to using a complex number for rotation
 typedef struct b2Rot
 {
-	/// sine and cosine
-	float s, c;
+	/// cosine and sine
+	float c, s;
 } b2Rot;
 
 /// A 2D rigid transform

--- a/include/box2d/timer.h
+++ b/include/box2d/timer.h
@@ -16,7 +16,7 @@ typedef struct b2Timer
 	unsigned long long start_sec;
 	unsigned long long start_usec;
 #else
-	int dummy;
+	int32_t dummy;
 #endif
 } b2Timer;
 

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -64,7 +64,7 @@ typedef struct b2WorldDef
 	/// Number of workers to use with the provided task system. Box2D performs best when using only
 	///	performance cores and accessing a single L2 cache. Efficiency cores and hyper-threading provide
 	///	little benefit and may even harm performance.
-	int workerCount;
+	int32_t workerCount;
 
 	/// Function to spawn tasks
 	b2EnqueueTaskCallback* enqueueTask;
@@ -232,7 +232,7 @@ typedef struct b2ChainDef
 	const b2Vec2* points;
 
 	/// The point count, must be 4 or more.
-	int count;
+	int32_t count;
 
 	/// Indicates a closed chain formed by connecting the first and last points
 	bool isLoop;
@@ -279,17 +279,17 @@ typedef struct b2Profile
 /// Counters that give details of the simulation size
 typedef struct b2Counters
 {
-	int staticBodyCount;
-	int bodyCount;
-	int shapeCount;
-	int contactCount;
-	int jointCount;
-	int islandCount;
-	int stackUsed;
-	int treeHeight;
-	int byteCount;
-	int taskCount;
-	int colorCounts[b2_graphColorCount];
+	int32_t staticBodyCount;
+	int32_t bodyCount;
+	int32_t shapeCount;
+	int32_t contactCount;
+	int32_t jointCount;
+	int32_t islandCount;
+	int32_t stackUsed;
+	int32_t treeHeight;
+	int32_t byteCount;
+	int32_t taskCount;
+	int32_t colorCounts[b2_graphColorCount];
 } b2Counters;
 
 /// Use this to initialize your world definition

--- a/samples/sample_benchmark.cpp
+++ b/samples/sample_benchmark.cpp
@@ -1269,7 +1269,7 @@ public:
 		b2ShapeDef shapeDef = b2DefaultShapeDef();
 
 		const char* text = "I";
-		int n = strlen(text);
+		int n = (int)strlen(text);
 		float zoom = 1.0f;
 
 		float x = 0.0f;

--- a/samples/sample_collision.cpp
+++ b/samples/sample_collision.cpp
@@ -19,7 +19,7 @@
 class SampleDistance : public Sample
 {
 public:
-	SampleDistance(Settings& settings)
+	explicit SampleDistance(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -173,6 +173,7 @@ public:
 
 		b2Color dim1 = {0.5f * color1.r, 0.5f * color1.g, 0.5f * color1.b, 1.0f};
 
+		// todo finish this sample
 #if 0
 		// circle-circle
 		{
@@ -475,7 +476,7 @@ static float RayCallback(const b2RayCastInput* input, int32_t proxyId, int32_t u
 class DynamicTree : public Sample
 {
 public:
-	DynamicTree(Settings& settings)
+	explicit DynamicTree(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -883,7 +884,7 @@ static int sampleDynamicTree = RegisterSample("Collision", "Dynamic Tree", Dynam
 class RayCast : public Sample
 {
 public:
-	RayCast(Settings& settings)
+	explicit RayCast(Settings& settings)
 		: Sample(settings)
 	{
 		m_circle = {{0.0f, 0.0f}, 2.0f};
@@ -1406,7 +1407,7 @@ public:
 		e_maxCount = 64
 	};
 
-	RayCastWorld(Settings& settings)
+	explicit RayCastWorld(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -1927,7 +1928,7 @@ public:
 		return true;
 	}
 
-	OverlapWorld(Settings& settings)
+	explicit OverlapWorld(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -2265,7 +2266,7 @@ static int sampleOverlapWorld = RegisterSample("Collision", "Overlap World", Ove
 class Manifold : public Sample
 {
 public:
-	Manifold(Settings& settings)
+	explicit Manifold(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -2977,7 +2978,7 @@ public:
 		e_boxShape
 	};
 
-	SmoothManifold(Settings& settings)
+	explicit SmoothManifold(Settings& settings)
 		: Sample(settings)
 	{
 		m_shapeType = e_boxShape;
@@ -3061,8 +3062,8 @@ public:
 	void UpdateUI() override
 	{
 		ImGui::SetNextWindowPos(ImVec2(10.0f, 100.0f));
-		ImGui::SetNextWindowSize(ImVec2(230.0f, 260.0f));
-		ImGui::Begin("Manifold Controls", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize);
+		ImGui::SetNextWindowSize(ImVec2(230.0f, 270.0f));
+		ImGui::Begin("Smooth Manifold", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize);
 
 		{
 			const char* shapeTypes[] = {"Circle", "Box"};
@@ -3269,7 +3270,7 @@ public:
 		e_vertexCount = 8
 	};
 
-	ShapeCast(Settings& settings)
+	explicit ShapeCast(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -3508,7 +3509,7 @@ static int sampleShapeCast = RegisterSample("Collision", "Shape Cast", ShapeCast
 class TimeOfImpact : public Sample
 {
 public:
-	TimeOfImpact(Settings& settings)
+	explicit TimeOfImpact(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)

--- a/samples/sample_continuous.cpp
+++ b/samples/sample_continuous.cpp
@@ -25,7 +25,7 @@ public:
 		e_boxShape
 	};
 
-	BounceHouse(Settings& settings)
+	explicit BounceHouse(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -131,7 +131,7 @@ static int sampleBounceHouse = RegisterSample("Continuous", "Bounce House", Boun
 class FastChain : public Sample
 {
 public:
-	FastChain(Settings& settings)
+	explicit FastChain(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -204,7 +204,7 @@ static int sampleFastChainHouse = RegisterSample("Continuous", "Fast Chain", Fas
 class SkinnyBox : public Sample
 {
 public:
-	SkinnyBox(Settings& settings)
+	explicit SkinnyBox(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -339,7 +339,7 @@ public:
 		e_boxShape
 	};
 
-	GhostCollision(Settings& settings)
+	explicit GhostCollision(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -549,8 +549,8 @@ public:
 	void UpdateUI() override
 	{
 		ImGui::SetNextWindowPos(ImVec2(10.0f, 100.0f), ImGuiCond_Once);
-		ImGui::SetNextWindowSize(ImVec2(240.0f, 130.0f));
-		ImGui::Begin("Options", nullptr, ImGuiWindowFlags_NoResize);
+		ImGui::SetNextWindowSize(ImVec2(240.0f, 160.0f));
+		ImGui::Begin("Ghost Collision", nullptr, ImGuiWindowFlags_NoResize);
 
 		if (ImGui::Checkbox("Chain", &m_useChain))
 		{
@@ -667,7 +667,7 @@ static int sampleSpeculativeFail = RegisterSample("Continuous", "Speculative Fai
 class Pinball : public Sample
 {
 public:
-	Pinball(Settings& settings)
+	explicit Pinball(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)

--- a/samples/sample_events.cpp
+++ b/samples/sample_events.cpp
@@ -25,7 +25,7 @@ public:
 		e_count = 32
 	};
 
-	SensorEvent(Settings& settings)
+	explicit SensorEvent(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -334,7 +334,7 @@ public:
 		e_count = 20
 	};
 
-	ContactEvent(Settings& settings)
+	explicit ContactEvent(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -903,7 +903,7 @@ public:
 		e_count = 50
 	};
 
-	BodyMove(Settings& settings)
+	explicit BodyMove(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)

--- a/samples/sample_geometry.cpp
+++ b/samples/sample_geometry.cpp
@@ -18,7 +18,7 @@ public:
 		e_count = b2_maxPolygonVertices
 	};
 
-	ConvexHull(Settings& settings)
+	explicit ConvexHull(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -217,7 +217,7 @@ static int sampleDistanceJoint = RegisterSample("Joints", "Distance Joint", Dist
 class MotorJoint : public Sample
 {
 public:
-	MotorJoint(Settings& settings)
+	explicit MotorJoint(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -504,7 +504,7 @@ static int sampleRevolute = RegisterSample("Joints", "Revolute", RevoluteJoint::
 class PrismaticJoint : public Sample
 {
 public:
-	PrismaticJoint(Settings& settings)
+	explicit PrismaticJoint(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -613,7 +613,7 @@ static int samplePrismatic = RegisterSample("Joints", "Prismatic", PrismaticJoin
 class WheelJoint : public Sample
 {
 public:
-	WheelJoint(Settings& settings)
+	explicit WheelJoint(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -740,7 +740,7 @@ public:
 		e_count = 160
 	};
 
-	Bridge(Settings& settings)
+	explicit Bridge(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -884,7 +884,7 @@ public:
 		e_count = 30
 	};
 
-	BallAndChain(Settings& settings)
+	explicit BallAndChain(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -1372,7 +1372,7 @@ static int sampleFixedRotation = RegisterSample("Joints", "Fixed Rotation", Fixe
 class UserConstraint : public Sample
 {
 public:
-	UserConstraint(Settings& settings)
+	explicit UserConstraint(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -1495,7 +1495,7 @@ static int sampleUserConstraintIndex = RegisterSample("Joints", "User Constraint
 class Car : public Sample
 {
 public:
-	Car(Settings& settings)
+	explicit Car(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -1831,7 +1831,7 @@ static int sampleCar = RegisterSample("Joints", "Car", Car::Create);
 class Ragdoll : public Sample
 {
 public:
-	Ragdoll(Settings& settings)
+	explicit Ragdoll(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -1864,7 +1864,7 @@ static int sampleRagdoll = RegisterSample("Joints", "Ragdoll", Ragdoll::Create);
 class SoftBody : public Sample
 {
 public:
-	SoftBody(Settings& settings)
+	explicit SoftBody(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)

--- a/samples/sample_robustness.cpp
+++ b/samples/sample_robustness.cpp
@@ -16,7 +16,7 @@
 class HighMassRatio1 : public Sample
 {
   public:
-	HighMassRatio1(Settings& settings)
+	explicit HighMassRatio1(Settings& settings)
 		: Sample(settings)
 	{
 		float extent = 1.0f;
@@ -74,7 +74,7 @@ static int sampleIndex1 = RegisterSample("Robustness", "HighMassRatio1", HighMas
 class HighMassRatio2 : public Sample
 {
   public:
-	HighMassRatio2(Settings& settings)
+	explicit HighMassRatio2(Settings& settings)
 		: Sample(settings)
 	{
 		{
@@ -128,7 +128,7 @@ static int sampleIndex2 = RegisterSample("Robustness", "HighMassRatio2", HighMas
 class OverlapRecovery : public Sample
 {
   public:
-	OverlapRecovery(Settings& settings)
+	explicit OverlapRecovery(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)

--- a/samples/sample_shapes.cpp
+++ b/samples/sample_shapes.cpp
@@ -1032,7 +1032,7 @@ public:
 
 		int count1 = std::size(points1);
 		int count2 = std::size(points2);
-		;
+
 		b2BodyDef bodyDef = b2DefaultBodyDef();
 		b2BodyId groundId = b2CreateBody(m_worldId, &bodyDef);
 

--- a/samples/sample_shapes.cpp
+++ b/samples/sample_shapes.cpp
@@ -40,7 +40,7 @@ public:
 		e_boxShape
 	};
 
-	ChainShape(Settings& settings)
+	explicit ChainShape(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -133,7 +133,7 @@ public:
 		m_groundId = b2CreateBody(m_worldId, &bodyDef);
 
 		m_chainId = b2CreateChain(m_groundId, &chainDef);
-	}
+		}
 
 	void Launch()
 	{
@@ -151,7 +151,7 @@ public:
 		shapeDef.density = 1.0f;
 		shapeDef.friction = m_friction;
 		shapeDef.restitution = m_restitution;
-
+	
 		if (m_shapeType == e_circleShape)
 		{
 			b2Circle circle = {{0.0f, 0.0f}, 0.5f};
@@ -227,13 +227,14 @@ public:
 
 static int sampleChainShape = RegisterSample("Shapes", "Chain Shape", ChainShape::Create);
 
+
 // This sample shows how careful creation of compound shapes leads to better simulation and avoids
 // objects getting stuck.
 // This also shows how to get the combined AABB for the body.
 class CompoundShapes : public Sample
 {
 public:
-	CompoundShapes(Settings& settings)
+	explicit CompoundShapes(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -463,7 +464,7 @@ public:
 		ALL_BITS = (~0u)
 	};
 
-	ShapeFilter(Settings& settings)
+	explicit ShapeFilter(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -676,7 +677,7 @@ public:
 		e_boxShape
 	};
 
-	Restitution(Settings& settings)
+	explicit Restitution(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -790,7 +791,7 @@ static int sampleIndex = RegisterSample("Shapes", "Restitution", Restitution::Cr
 class Friction : public Sample
 {
 public:
-	Friction(Settings& settings)
+	explicit Friction(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -1012,3 +1013,83 @@ public:
 };
 
 static int sampleModifyGeometry = RegisterSample("Shapes", "Modify Geometry", ModifyGeometry::Create);
+
+// Shows how to link to chain shapes together. This is a useful technique for building large game levels with smooth collision.
+class ChainLink : public Sample
+{
+public:
+	explicit ChainLink(Settings& settings)
+		: Sample(settings)
+	{
+		if (settings.restart == false)
+		{
+			g_camera.m_center = {0.0f, 5.0f};
+			g_camera.m_zoom = 0.5f;
+		}
+
+		b2Vec2 points1[] = {{40.0f, 1.0f}, {0.0f, 0.0f}, {-40.0f, 0.0f}, {-40.0f, -1.0f}, {0.0f, -1.0f}, {40.0f, -1.0f}};
+		b2Vec2 points2[] = {{-40.0f, -1.0f}, {0.0f, -1.0f}, {40.0f, -1.0f}, {40.0f, 0.0f}, {0.0f, 0.0f}, {-40.0f, 0.0f}};
+
+		int count1 = std::size(points1);
+		int count2 = std::size(points2);
+		;
+		b2BodyDef bodyDef = b2DefaultBodyDef();
+		b2BodyId groundId = b2CreateBody(m_worldId, &bodyDef);
+
+		{
+			b2ChainDef chainDef = b2DefaultChainDef();
+			chainDef.points = points1;
+			chainDef.count = count1;
+			chainDef.isLoop = false;
+			b2CreateChain(groundId, &chainDef);
+		}
+
+		{
+			b2ChainDef chainDef = b2DefaultChainDef();
+			chainDef.points = points2;
+			chainDef.count = count2;
+			chainDef.isLoop = false;
+			b2CreateChain(groundId, &chainDef);
+		}
+
+		bodyDef.type = b2_dynamicBody;
+		b2ShapeDef shapeDef = b2DefaultShapeDef();
+
+		{
+			bodyDef.position = {-5.0f, 2.0f};
+			b2BodyId bodyId = b2CreateBody(m_worldId, &bodyDef);
+			b2Circle circle = {{0.0f, 0.0f}, 0.5f};
+			b2CreateCircleShape(bodyId, &shapeDef, &circle);
+		}
+
+		{
+			bodyDef.position = {0.0f, 2.0f};
+			b2BodyId bodyId = b2CreateBody(m_worldId, &bodyDef);
+			b2Capsule capsule = {{-0.5f, 0.0f}, {0.5f, 0.0}, 0.25f};
+			b2CreateCapsuleShape(bodyId, &shapeDef, &capsule);
+		}
+
+		{
+			bodyDef.position = {5.0f, 2.0f};
+			b2BodyId bodyId = b2CreateBody(m_worldId, &bodyDef);
+			float h = 0.5f;
+			b2Polygon box = b2MakeBox(h, h);
+			b2CreatePolygonShape(bodyId, &shapeDef, &box);
+		}
+	}
+
+	void Step(Settings& settings) override
+	{
+		Sample::Step(settings);
+
+		g_draw.DrawString(5, m_textLine, "This shows how to link together two chain shapes");
+		m_textLine += m_textIncrement;
+	}
+
+	static Sample* Create(Settings& settings)
+	{
+		return new ChainLink(settings);
+	}
+};
+
+static int sampleChainLink = RegisterSample("Shapes", "Chain Link", ChainLink::Create);

--- a/samples/sample_stacking.cpp
+++ b/samples/sample_stacking.cpp
@@ -61,7 +61,7 @@ public:
 		e_rows = 10,
 	};
 
-	TiltedStack(Settings& settings)
+	explicit TiltedStack(Settings& settings)
 		: Sample(settings)
 	{
 		{
@@ -136,7 +136,7 @@ public:
 		e_boxShape
 	};
 
-	VerticalStack(Settings& settings)
+	explicit VerticalStack(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -373,7 +373,7 @@ static int sampleVerticalStack = RegisterSample("Stacking", "Vertical Stack", Ve
 class Cliff : public Sample
 {
 public:
-	Cliff(Settings& settings)
+	explicit Cliff(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -615,7 +615,7 @@ static int sampleArch = RegisterSample("Stacking", "Arch", Arch::Create);
 class DoubleDomino : public Sample
 {
 public:
-	DoubleDomino(Settings& settings)
+	explicit DoubleDomino(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -674,7 +674,7 @@ public:
 		e_maxCount = e_gridCount * e_gridCount
 	};
 
-	Confined(Settings& settings)
+	explicit Confined(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)
@@ -745,7 +745,7 @@ static int sampleConfined = RegisterSample("Stacking", "Confined", Confined::Cre
 class CardHouse : public Sample
 {
 public:
-	CardHouse(Settings& settings)
+	explicit CardHouse(Settings& settings)
 		: Sample(settings)
 	{
 		if (settings.restart == false)

--- a/src/body.h
+++ b/src/body.h
@@ -76,12 +76,12 @@ typedef struct b2BodyState
 	b2Vec2 deltaPosition; // 8
 
 	// Using delta rotation because I cannot access the full rotation on static bodies in
-	// the solver and must use zero delta rotation for static bodies (s,c) = (0,1)
+	// the solver and must use zero delta rotation for static bodies (c,s) = (1,0)
 	b2Rot deltaRotation; // 8
 } b2BodyState;
 
-// Identity body state, notice the deltaRotation is {0, 1}
-static const b2BodyState b2_identityBodyState = {{0.0f, 0.0f}, 0.0f, 0, {0.0f, 0.0f}, {0.0f, 1.0f}};
+// Identity body state, notice the deltaRotation is {1, 0}
+static const b2BodyState b2_identityBodyState = {{0.0f, 0.0f}, 0.0f, 0, {0.0f, 0.0f}, {1.0f, 0.0f}};
 
 // Body simulation data used for integration of position and velocity
 // Transform data used for collision and solver preparation.

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -379,12 +379,10 @@ void b2ApplyOverflowRestitution(b2StepContext* context)
 		b2BodyState* stateA = constraint->indexA == B2_NULL_INDEX ? &dummyState : states + constraint->indexA;
 		b2Vec2 vA = stateA->linearVelocity;
 		float wA = stateA->angularVelocity;
-		b2Rot dqA = stateA->deltaRotation;
 
 		b2BodyState* stateB = constraint->indexB == B2_NULL_INDEX ? &dummyState : states + constraint->indexB;
 		b2Vec2 vB = stateB->linearVelocity;
 		float wB = stateB->angularVelocity;
-		b2Rot dqB = stateB->deltaRotation;
 
 		b2Vec2 normal = constraint->normal;
 		int pointCount = constraint->pointCount;
@@ -505,8 +503,8 @@ static b2SimdBody b2GatherBodies(const b2BodyState* restrict states, int* restri
 {
 	_Static_assert(sizeof(b2BodyState) == 32, "b2BodyState not 32 bytes");
 	B2_ASSERT(((uintptr_t)states & 0x1F) == 0);
-	// static const b2BodyState b2_identityBodyState = {{0.0f, 0.0f}, 0.0f, 0, {0.0f, 0.0f}, {0.0f, 1.0f}};
-	b2FloatW identity = simde_mm256_setr_ps(0.0f, 0.0f, 0.0f, 0, 0.0f, 0.0f, 0.0f, 1.0f);
+	// static const b2BodyState b2_identityBodyState = {{0.0f, 0.0f}, 0.0f, 0, {0.0f, 0.0f}, {1.0f, 0.0f}};
+	b2FloatW identity = simde_mm256_setr_ps(0.0f, 0.0f, 0.0f, 0, 0.0f, 0.0f, 1.0f, 0.0f);
 	b2FloatW b0 = indices[0] == B2_NULL_INDEX ? identity : simde_mm256_load_ps((float*)(states + indices[0]));
 	b2FloatW b1 = indices[1] == B2_NULL_INDEX ? identity : simde_mm256_load_ps((float*)(states + indices[1]));
 	b2FloatW b2 = indices[2] == B2_NULL_INDEX ? identity : simde_mm256_load_ps((float*)(states + indices[2]));
@@ -540,8 +538,8 @@ static b2SimdBody b2GatherBodies(const b2BodyState* restrict states, int* restri
 	simdBody.flags = simde_mm256_permute2f128_ps(tt3, tt7, 0x20);
 	simdBody.dp.X = simde_mm256_permute2f128_ps(tt0, tt4, 0x31);
 	simdBody.dp.Y = simde_mm256_permute2f128_ps(tt1, tt5, 0x31);
-	simdBody.dq.S = simde_mm256_permute2f128_ps(tt2, tt6, 0x31);
-	simdBody.dq.C = simde_mm256_permute2f128_ps(tt3, tt7, 0x31);
+	simdBody.dq.C = simde_mm256_permute2f128_ps(tt2, tt6, 0x31);
+	simdBody.dq.S = simde_mm256_permute2f128_ps(tt3, tt7, 0x31);
 	return simdBody;
 }
 
@@ -556,8 +554,8 @@ static void b2ScatterBodies(b2BodyState* restrict states, int* restrict indices,
 	b2FloatW t3 = simde_mm256_unpackhi_ps(simdBody->w, simdBody->flags);
 	b2FloatW t4 = simde_mm256_unpacklo_ps(simdBody->dp.X, simdBody->dp.Y);
 	b2FloatW t5 = simde_mm256_unpackhi_ps(simdBody->dp.X, simdBody->dp.Y);
-	b2FloatW t6 = simde_mm256_unpacklo_ps(simdBody->dq.S, simdBody->dq.C);
-	b2FloatW t7 = simde_mm256_unpackhi_ps(simdBody->dq.S, simdBody->dq.C);
+	b2FloatW t6 = simde_mm256_unpacklo_ps(simdBody->dq.C, simdBody->dq.S);
+	b2FloatW t7 = simde_mm256_unpackhi_ps(simdBody->dq.C, simdBody->dq.S);
 	b2FloatW tt0 = simde_mm256_shuffle_ps(t0, t2, SIMDE_MM_SHUFFLE(1, 0, 1, 0));
 	b2FloatW tt1 = simde_mm256_shuffle_ps(t0, t2, SIMDE_MM_SHUFFLE(3, 2, 3, 2));
 	b2FloatW tt2 = simde_mm256_shuffle_ps(t1, t3, SIMDE_MM_SHUFFLE(1, 0, 1, 0));

--- a/src/distance.c
+++ b/src/distance.c
@@ -21,8 +21,8 @@ b2Transform b2GetSweepTransform(const b2Sweep* sweep, float time)
 	xf.p = b2Add(b2MulSV(1.0f - time, sweep->c1), b2MulSV(time, sweep->c2));
 
 	b2Rot q = {
-		(1.0f - time) * sweep->q1.s + time * sweep->q2.s,
 		(1.0f - time) * sweep->q1.c + time * sweep->q2.c,
+		(1.0f - time) * sweep->q1.s + time * sweep->q2.s,
 	};
 
 	xf.q = b2NormalizeRot(q);

--- a/src/manifold.c
+++ b/src/manifold.c
@@ -10,8 +10,6 @@
 #include "box2d/math_functions.h"
 
 #include <float.h>
-#include <stdatomic.h>
-#include <string.h>
 
 #define B2_MAKE_ID(A, B) ((uint8_t)(A) << 8 | (uint8_t)(B))
 
@@ -1064,7 +1062,8 @@ b2Manifold b2CollideSmoothSegmentAndPolygon(const b2SmoothSegment* smoothSegment
 				{
 					return manifold;
 				}
-				else if (type == b2_normalAdmit)
+				
+				if (type == b2_normalAdmit)
 				{
 					// Get polygon edge associated with normal
 					ib1 = ib;
@@ -1187,11 +1186,17 @@ b2Manifold b2CollideSmoothSegmentAndPolygon(const b2SmoothSegment* smoothSegment
 		{
 			b2Vec2 n = normals[i];
 
-			// Check the infinite sides of the partial polygon
-			if ((smoothParams.convex1 && b2Cross(n0, n) > 0.0f) || (smoothParams.convex2 && b2Cross(n, n2) > 0.0f))
+			enum b2NormalType type = b2ClassifyNormal(smoothParams, b2Neg(n));
+			if (type != b2_normalAdmit)
 			{
 				continue;
 			}
+
+			// Check the infinite sides of the partial polygon
+			//if ((smoothParams.convex1 && b2Cross(n0, n) > 0.0f) || (smoothParams.convex2 && b2Cross(n, n2) > 0.0f))
+			//{
+			//	continue;
+			//}
 
 			b2Vec2 p = vertices[i];
 			float s = B2_MIN(b2Dot(n, b2Sub(p2, p)), b2Dot(n, b2Sub(p1, p)));

--- a/src/shape.h
+++ b/src/shape.h
@@ -17,6 +17,7 @@ typedef struct b2Shape
 {
 	int id;
 	int bodyId;
+	int prevShapeId;
 	int nextShapeId;
 	b2ShapeType type;
 	float density;

--- a/src/world.c
+++ b/src/world.c
@@ -2088,6 +2088,32 @@ void b2ValidateSolverSets(b2World* world)
 						B2_ASSERT(body->headContactKey == B2_NULL_INDEX);
 					}
 
+					// Validate body shapes
+					int prevShapeId = B2_NULL_INDEX;
+					int shapeId = body->headShapeId;
+					while (shapeId != B2_NULL_INDEX)
+					{
+						b2CheckId(world->shapeArray, shapeId);
+						b2Shape* shape = world->shapeArray + shapeId;
+						B2_ASSERT(shape->prevShapeId == prevShapeId);
+
+						if (setIndex == b2_disabledSet)
+						{
+							B2_ASSERT(shape->proxyKey == B2_NULL_INDEX);
+						}
+						else if (setIndex == b2_staticSet)
+						{
+							B2_ASSERT(B2_PROXY_TYPE(shape->proxyKey) == b2_staticProxy);
+						}
+						else
+						{
+							B2_ASSERT(B2_PROXY_TYPE(shape->proxyKey) == b2_movableProxy);
+						}
+
+						prevShapeId = shapeId;
+						shapeId = shape->nextShapeId;
+					}
+
 					// Validate body contacts
 					int contactKey = body->headContactKey;
 					while (contactKey != B2_NULL_INDEX)


### PR DESCRIPTION
Added sample that shows how to connect two chain shapes.
b2Rot now has cosine first.
Fixed polygon versus smooth segment collision for concave portion.
Shapes are now connected to bodies using a doubly linked list for fast removal.
API structures now using int32_t instead of int for easier binding.

fixes #117
fixes #105 
