### PR TITLE
Temporary variable being used as a permanent variable

### DIFF
--- a/src/solver.c
+++ b/src/solver.c
@@ -1669,8 +1669,7 @@ void b2Solve(b2World* world, b2StepContext* stepContext)
 	// Report hit events
 	// todo perhaps optimize this with a bitset
 	{
-		b2ContactHitEvent* events = world->contactHitArray;
-		B2_ASSERT(b2Array(events).count == 0);
+		B2_ASSERT(b2Array(world->contactHitArray).count == 0);
 
 		float threshold = world->hitEventThreshold;
 		b2GraphColor* colors = world->constraintGraph.colors;
@@ -1716,7 +1715,7 @@ void b2Solve(b2World* world, b2StepContext* stepContext)
 					event.shapeIdA = (b2ShapeId){shapeA->id + 1, world->worldId, shapeA->revision};
 					event.shapeIdB = (b2ShapeId){shapeB->id + 1, world->worldId, shapeB->revision};
 
-					b2Array_Push(events, event);
+					b2Array_Push(world->contactHitArray, event);
 				}
 			}
 		}


### PR DESCRIPTION
A temporary variable was being passed into push, which, when the array grows, the new array was being written to the temp variable in the macro.

Pull requests for core Box2D code are generally not accepted. Please consider filing an issue instead.

However, pull requests for build system improvements are often accepted.
